### PR TITLE
test run as action

### DIFF
--- a/.github/test-build-script.sh
+++ b/.github/test-build-script.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo $(calculate_paths_fingerprint ./.github/workflows)
+echo "This has been a successful test."

--- a/.github/workflows/test-run-as-action.yml
+++ b/.github/workflows/test-run-as-action.yml
@@ -9,4 +9,12 @@ jobs:
   test-run-as-action:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: docker://ghcr.io/uwit-iam/common-build-scripts:latest
+        name: Run a command on the image directly
+        with:
+          args: calculate_paths_fingerprint sources
+      - uses: docker://ghcr.io/uwit-iam/common-build-scripts:latest
+        name: Run a script that invokes the commands
+        with:
+          args: ./.github/test-build-script.sh

--- a/scripts/pull-or-build-image.sh
+++ b/scripts/pull-or-build-image.sh
@@ -1,0 +1,78 @@
+function print_help {
+   cat <<EOF
+   Use: pull-or-build-image.sh [--debug --help]
+   Options:
+   --image -i         The image repository (e.g., gcr.io/my-project/my-image:unique-tag)
+   --dockerfile -d    The dockerfile used to build this image
+   --force-build -f   Build the image even if it already exists.
+   --push -p          Push the image when complete
+   --                 Pass all remaining arguments to the 'docker build' command
+   --help -h          Show this message and exit
+   --debug -g         Show commands as they are executing
+EOF
+}
+
+DEBUG=${DEBUG}
+docker_build_args=
+docker_context=.
+dockerfile=Dockerfile
+
+while (( $# ))
+do
+  case $1 in
+    --help|-h)
+      print_help
+      exit 0
+      ;;
+    --debug|-g)
+      DEBUG=1
+      ;;
+    --image|-i)
+      shift
+      image="$1"
+      ;;
+    --docker-context|-c)
+      shift
+      docker_context=$1
+      ;;
+    --dockerfile|-d)
+      shift
+      dockerfile="$1"
+      ;;
+    --force-build|-f)
+      force_build=1
+      ;;
+    --push-image|-p)
+      push_image=1
+      ;;
+    --)
+      shift
+      docker_build_args="$@"
+      break
+      ;;
+    *)
+      echo "Invalid Option: $1"
+      print_help
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+test -z "${DEBUG}" || set -x
+
+
+if docker pull $image > /dev/null
+then
+  echo "Image already built: $image"
+  test -n "${force_build}" || exit 0
+fi
+
+echo "Building image: $image"
+docker build -f $dockerfile $docker_build_args -t $image $docker_context
+
+if [[ -n "$push_image" ]]
+then
+  echo "Pushing image: $image"
+  docker push $image
+fi

--- a/sources/bash-testing.sh
+++ b/sources/bash-testing.sh
@@ -38,6 +38,34 @@ function assert_output_matches {
   fi
 }
 
+function assert_output_matches_pattern {
+  local cmd="$1"
+  local expected="$2"
+  output="$(eval $cmd)"
+  if ! [[ "$output" =~ $expected ]]
+  then
+    log_failure
+    echo ".... expected '$expected' "
+    echo ".... received '$output'"
+  else
+    log_assertion_status OK
+  fi
+}
+
+function assert_not_output_matches_pattern {
+  local cmd="$1"
+  local expected="$2"
+  output="$(eval $cmd)"
+  if [[ "$output" =~ $expected ]]
+  then
+    log_failure
+    echo ".... expected not to receive output: "
+    echo "...... $output"
+  else
+    log_assertion_status OK
+  fi
+}
+
 function assert_not_output_matches {
   local cmd="$1"
   local expected="$2"

--- a/tests/scripts/test-pull-or-build-image.sh
+++ b/tests/scripts/test-pull-or-build-image.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+source $PWD/sources/bash-testing.sh
+script_name=pull-or-build-image.sh
+existing_image="ghcr.io/uwit-iam/common-build-scripts:release"
+new_image="ghcr.io/uwit-iam/common-build-scripts:codswallop"
+
+function test_image_already_exists {
+  local test_name='test_image_already_exists'
+  echo $test_name
+  local cmd="$PWD/scripts/$script_name -i $existing_image -d Dockerfile"
+  set_up_assertion 'when image already exists, it is not re-built'
+  assert_output_matches_pattern "$cmd" "Image already built: $existing_image"
+  assert_not_output_matches_pattern "$cmd" "Building image: $existing_image"
+}
+
+function test_image_already_exists_force_rebuild {
+  local test_name='test_image_already_exists_force_rebuild'
+  echo $test_name
+  local cmd="$PWD/scripts/$script_name -i $existing_image -d Dockerfile --force-build"
+  set_up_assertion 'when image already exists and --force-build is set, it is re-built'
+  assert_output_matches_pattern "$cmd" "Image already built: $existing_image"
+  assert_output_matches_pattern "$cmd" "Building image: $existing_image"
+}
+
+function test_image_does_not_exist_builds {
+  local test_name='test_image_does_not_exist_builds'
+  echo $test_name
+  local cmd="$PWD/scripts/$script_name -i $new_image -d Dockerfile"
+  set_up_assertion 'when image does not exist, it is built'
+  assert_output_matches_pattern "$cmd" "Building image: $new_image"
+  docker rmi $new_image >/dev/null
+}
+
+test_image_already_exists
+test_image_already_exists_force_rebuild
+test_image_does_not_exist_builds
+finalize_tests


### PR DESCRIPTION
- Ensure path to entrypoint is absolute.
- Support `assert_[not]_output_matches_pattern` bash-testing functions
- Add script: `pull-or-build-image.sh`
